### PR TITLE
Improved VNAV descend speeds

### DIFF
--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B787_10/FMC/B787_10_FMC.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B787_10/FMC/B787_10_FMC.js
@@ -1430,7 +1430,7 @@ class B787_10_FMC extends Heavy_Boeing_FMC {
 
 	getDesManagedSpeed() {
 		let dCI = this.getCostIndexFactor();
-		let speed = 290 * (1 - dCI) + 210 * dCI;
+		let speed = 290 + 50 * dCI;
 		if (this.overSpeedLimitThreshold) {
 			if (Simplane.getAltitude() < 10700) {
 				speed = Math.min(speed, 240);

--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B787_10/FMC/B787_10_FMC.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B787_10/FMC/B787_10_FMC.js
@@ -1430,7 +1430,7 @@ class B787_10_FMC extends Heavy_Boeing_FMC {
 
 	getDesManagedSpeed() {
 		let dCI = this.getCostIndexFactor();
-		let speed = 280 * (1 - dCI) + 300 * dCI;
+		let speed = 290 * (1 - dCI) + 210 * dCI;
 		if (this.overSpeedLimitThreshold) {
 			if (Simplane.getAltitude() < 10700) {
 				speed = Math.min(speed, 240);


### PR DESCRIPTION
VNAV descend speeds now begin from 290 IAS, which fits to calculated top of descend point more. At cost index 1000 the speed is about 334 IAS.