### PR TITLE
Add link to development build zip to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ B78XH is an open source and free modification of default Boeing 787-10 in Micros
 WO release is same as normal release but the release does not contain managers. (Payload and SimRate manager) 
 
 ## Installation
+
 To install, download the [latest release](https://github.com/Heavy-Division/B78XH/releases) zip and extract it to your Community folder.
 
 ## Features Overview

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ B78XH is an open source and free modification of default Boeing 787-10 in Micros
 
 WO release is same as normal release but the release does not contain managers. (Payload and SimRate manager) 
 
+## Installation
+To install, download the [latest release](https://github.com/Heavy-Division/B78XH/releases) zip and extract it to your Community folder.
+
 ## Features Overview
 
 * ### FMC

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ WO release is same as normal release but the release does not contain managers. 
 
 To install, download the [latest release](https://github.com/Heavy-Division/B78XH/releases) zip and extract it to your Community folder.
 
+## Development build
+
+The zip containing the development build can be downloaded here: https://github.com/Heavy-Division/B78XH/archive/refs/heads/main.zip
+
 ## Features Overview
 
 * ### FMC


### PR DESCRIPTION
This PR is based on `opr:update/readme-installation-instructions`, it adds a link to the development build to the readme.

Fixes #160