### PR TITLE
 feat: gradually remove CLB1/2 N1 limit as climbing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Change Log
 
 **Implemented enhancements:**
+
 CLB1/2 - Climb thrust derates that are gradually removed as the aircraft climbs.
 - CLB1/2 typically uses a 8.6/17.2% derate of CLB thrust to 10,000ft, then increases thrust linearly with altitude to CLB thrust at 30,000ft.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 
 CLB1/2 - Climb thrust derates that are gradually removed as the aircraft climbs.
 - CLB1/2 typically uses a 8.6/17.2% derate of CLB thrust to 10,000ft, then increases thrust linearly with altitude to CLB thrust at 30,000ft.
+ Reference : [Figure 4. Climb derate tapers](https://www.theairlinepilots.com/forumarchive/quickref/deratedclimbperformance.pdf)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,4 @@
 
 CLB1/2 - Climb thrust derates that are gradually removed as the aircraft climbs.
 - CLB1/2 typically uses a 8.6/17.2% derate of CLB thrust to 10,000ft, then increases thrust linearly with altitude to CLB thrust at 30,000ft.
- Reference : [Figure 4. Climb derate tapers](https://www.theairlinepilots.com/forumarchive/quickref/deratedclimbperformance.pdf)
+ Reference : [Rolls-Royce Derated Climb Performance In Large Civinl Aircraft - Article 6 - Figure 4. Climb derate tapers](https://www.theairlinepilots.com/forumarchive/quickref/deratedclimbperformance.pdf)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,4 @@
 
 CLB1/2 - Climb thrust derates that are gradually removed as the aircraft climbs.
 - CLB1/2 typically uses a 8.6/17.2% derate of CLB thrust to 10,000ft, then increases thrust linearly with altitude to CLB thrust at 30,000ft.
-References : 
-787 FCOM (FMC - Derated Thrust Climb : 11.32.4)
-GE Economic Impact of Derated Climb on Large Commercial Engines Article 8 - Figure 1. Climb thrust derate options
-Rolls-Royce Derated Climb Performance In Large Civinl Aircraft Article 6 - Figure 4. Climb derate tapers
+ Reference : [Rolls-Royce Derated Climb Performance In Large Civinl Aircraft - Article 6 - Figure 4. Climb derate tapers](https://www.theairlinepilots.com/forumarchive/quickref/deratedclimbperformance.pdf)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,7 @@
 
 CLB1/2 - Climb thrust derates that are gradually removed as the aircraft climbs.
 - CLB1/2 typically uses a 8.6/17.2% derate of CLB thrust to 10,000ft, then increases thrust linearly with altitude to CLB thrust at 30,000ft.
- Reference : [Rolls-Royce Derated Climb Performance In Large Civinl Aircraft - Article 6 - Figure 4. Climb derate tapers](https://www.theairlinepilots.com/forumarchive/quickref/deratedclimbperformance.pdf)
+References : 
+787 FCOM (FMC - Derated Thrust Climb : 11.32.4)
+GE Economic Impact of Derated Climb on Large Commercial Engines Article 8 - Figure 1. Climb thrust derate options
+Rolls-Royce Derated Climb Performance In Large Civinl Aircraft Article 6 - Figure 4. Climb derate tapers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,5 @@
-# Changelog
+# Change Log
 
-## [Unreleased]
-
-### Added
- - VNAV CLB CRZ altitude is highlighted by magenta when CRZ altitude is commanded by FMC
- - Option to permanently hide Heavy managers from FMC
- - Support for leveling off during climb
- - Whenever the airplane is leveled off because of MCP altitude during climb phase, setting new altitude in the MCP altitude window and pushing the altitude selector continues the climb.
-
-### Changed
- - Altitude intervention overrides CRZ altitude only when MCP altitude window is set above CRZ altitude
- - Aircraft switch to "VNAV ALT" mode and level off at MCP window altitude when the altitude is set to a value below CRZ altitude
-
-### Removed
- - Removed strings from VNAV CRZ page - "pause @ TOD" and so on
- - Removed ASOBO implementation of overriding CRZ Altitude by MCP altitude knob without pushing altitude intervention 
-
-[unreleased]: https://github.com/Heavy-Division/B78XHL/compare/v.0.1.3...main
+**Implemented enhancements:**
+CLB1/2 - Climb thrust derates that are gradually removed as the aircraft climbs.
+- CLB1/2 typically uses a 8.6/17.2% derate of CLB thrust to 10,000ft, then increases thrust linearly with altitude to CLB thrust at 30,000ft.

--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B787_10/FMC/hdfmc.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B787_10/FMC/hdfmc.js
@@ -18722,10 +18722,27 @@
             }
             return 100;
         }
+        getAltitudeCLB(altitude) {
+            if (altitude < 10000) {
+                let altitudeCLB;
+                altitudeCLB = 1;
+                return altitudeCLB;
+            }
+            else if (altitude > 30000) {
+                let altitudeCLB;
+                altitudeCLB = 0;
+                return altitudeCLB;
+            }
+            else {
+                let altitudeCLB;
+                altitudeCLB = 0.01 * Math.floor(100 * (30000 - altitude) / 20000);
+                return altitudeCLB;
+            }
+        }
         getThrustClimbLimit() {
             let altitude = Simplane.getAltitude();
             let temperature = SimVar.GetSimVarValue('AMBIENT TEMPERATURE', 'celsius');
-            return this.getClimbThrustN1(temperature, altitude) - this.getThrustCLBMode() * 8.6;
+            return this.getClimbThrustN1(temperature, altitude) - this.getThrustCLBMode() * 8.6 * this.getAltitudeCLB(altitude);
         }
         /**
          * TODO commented out. This is need only for testing

--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B787_10/FMC/hdfmc.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B787_10/FMC/hdfmc.js
@@ -18722,23 +18722,27 @@
             }
             return 100;
         }
-        getDeratedClimbThrustN1(altitude) {
-            let DeratedClimbThrustN1;
+        getAltitudeCLB(altitude) {
             if (altitude < 10000) {
-                DeratedClimbThrustN1 = 1;
+                let altitudeCLB;
+                altitudeCLB = 1;
+                return altitudeCLB;
             }
             else if (altitude > 30000) {
-                DeratedClimbThrustN1 = 0;
+                let altitudeCLB;
+                altitudeCLB = 0;
+                return altitudeCLB;
             }
             else {
-                DeratedClimbThrustN1 = 0.01 * Math.floor(100 * (30000 - altitude) / 20000);
+                let altitudeCLB;
+                altitudeCLB = 0.01 * Math.floor(100 * (30000 - altitude) / 20000);
+                return altitudeCLB;
             }
-            return DeratedClimbThrustN1;
         }
         getThrustClimbLimit() {
             let altitude = Simplane.getAltitude();
             let temperature = SimVar.GetSimVarValue('AMBIENT TEMPERATURE', 'celsius');
-            return this.getClimbThrustN1(temperature, altitude) - this.getThrustCLBMode() * 8.6 * this.getDeratedClimbThrustN1(altitude);
+            return this.getClimbThrustN1(temperature, altitude) - this.getThrustCLBMode() * 8.6 * this.getAltitudeCLB(altitude);
         }
         /**
          * TODO commented out. This is need only for testing

--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B787_10/FMC/hdfmc.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B787_10/FMC/hdfmc.js
@@ -18722,27 +18722,10 @@
             }
             return 100;
         }
-        getAltitudeCLB(altitude) {
-            if (altitude < 10000) {
-                let altitudeCLB;
-                altitudeCLB = 1;
-                return altitudeCLB;
-            }
-            else if (altitude > 30000) {
-                let altitudeCLB;
-                altitudeCLB = 0;
-                return altitudeCLB;
-            }
-            else {
-                let altitudeCLB;
-                altitudeCLB = 0.01 * Math.floor(100 * (30000 - altitude) / 20000);
-                return altitudeCLB;
-            }
-        }
         getThrustClimbLimit() {
             let altitude = Simplane.getAltitude();
             let temperature = SimVar.GetSimVarValue('AMBIENT TEMPERATURE', 'celsius');
-            return this.getClimbThrustN1(temperature, altitude) - this.getThrustCLBMode() * 8.6 * this.getAltitudeCLB(altitude);
+            return this.getClimbThrustN1(temperature, altitude) - this.getThrustCLBMode() * 8.6;
         }
         /**
          * TODO commented out. This is need only for testing

--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B787_10/FMC/hdfmc.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B787_10/FMC/hdfmc.js
@@ -18722,27 +18722,23 @@
             }
             return 100;
         }
-        getAltitudeCLB(altitude) {
+        getDeratedClimbThrustN1(altitude) {
+            let DeratedClimbThrustN1;
             if (altitude < 10000) {
-                let altitudeCLB;
-                altitudeCLB = 1;
-                return altitudeCLB;
+                DeratedClimbThrustN1 = 1;
             }
             else if (altitude > 30000) {
-                let altitudeCLB;
-                altitudeCLB = 0;
-                return altitudeCLB;
+                DeratedClimbThrustN1 = 0;
             }
             else {
-                let altitudeCLB;
-                altitudeCLB = 0.01 * Math.floor(100 * (30000 - altitude) / 20000);
-                return altitudeCLB;
+                DeratedClimbThrustN1 = 0.01 * Math.floor(100 * (30000 - altitude) / 20000);
             }
+            return DeratedClimbThrustN1;
         }
         getThrustClimbLimit() {
             let altitude = Simplane.getAltitude();
             let temperature = SimVar.GetSimVarValue('AMBIENT TEMPERATURE', 'celsius');
-            return this.getClimbThrustN1(temperature, altitude) - this.getThrustCLBMode() * 8.6 * this.getAltitudeCLB(altitude);
+            return this.getClimbThrustN1(temperature, altitude) - this.getThrustCLBMode() * 8.6 * this.getDeratedClimbThrustN1(altitude);
         }
         /**
          * TODO commented out. This is need only for testing

--- a/src/hdfmc/fmc/B787_10_FMC.ts
+++ b/src/hdfmc/fmc/B787_10_FMC.ts
@@ -940,10 +940,24 @@ export class B787_10_FMC extends Boeing_FMC {
 		return 100;
 	}
 
+	getDeratedClimbThrustN1(altitude) {
+		let DeratedClimbThrustN1;
+		if (altitude < 10000) {
+			DeratedClimbThrustN1 = 1;
+		}
+		else if (altitude > 30000) {
+			DeratedClimbThrustN1 = 0;
+		}
+		else {
+			DeratedClimbThrustN1 = 0.01 * Math.floor(100 * (30000 - altitude) / 20000);
+		}
+		return DeratedClimbThrustN1;
+	}
+
 	getThrustClimbLimit() {
 		let altitude = Simplane.getAltitude();
 		let temperature = SimVar.GetSimVarValue('AMBIENT TEMPERATURE', 'celsius');
-		return this.getClimbThrustN1(temperature, altitude) - this.getThrustCLBMode() * 8.6;
+		return this.getClimbThrustN1(temperature, altitude) - this.getThrustCLBMode() * 8.6 * this.getDeratedClimbThrustN1(altitude);
 	}
 
 	/**


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
<!-- Failure to follow the Pull Request template may result in your PR being ignored -->

# Title
 feat: gradually remove CLB1/2 N1 limit as climbing

<!-- Use an appropriate title -->
<!--Please use the appropriate prefix in your PR Title-->

<!--
* feat: A new feature<br><br>
* fix: A bug fix<br><br>
* docs: Documentation only changes<br><br>
* style: Formatting, missing semi-colons, white-space, etc<br><br>
* refactor: A code change that neither fixes a bug nor adds a feature<br><br>
* perf: A code change that improves performance<br><br>
* test: Adding missing tests<br><br>
* chore : Maintain. Changes to the build process or auxiliary tools/libraries/documentation
-->

# Description 
When the altitude is above 10,000 feet and below 30,000 feet and CLB1/CLB2 is set, the attenuation of ThrustClimbLimit is adjusted in 1% increments.
<!--Give a description about what you have added/changed, what it does, and what the command/alias is.-->


# Source material
CLB1 & CLB 2 - Climb thrust derates that are gradually removed as the aircraft climbs.
References : 
- 787 FCOM (FMC - Derated Thrust Climb : 11.32.4)
- [GE Economic Impact of Derated Climb on Large Commercial Engines Article 8 - Figure 1. Climb thrust derate options](https://www.smartcockpit.com/docs/Economic_Impact_of_Derated_Climb_on_Large_Commercial_Engines.pdf)
- [Rolls-Royce Derated Climb Performance In Large Civinl Aircraft Article 6 - Figure 4. Climb derate tapers](https://www.theairlinepilots.com/forumarchive/quickref/deratedclimbperformance.pdf)
<!-- If adding a feature or element found in the aircraft, please cite the documentation or source you found it from. Sources from P3D, xplane, and fsx are not valid unless the documentation is otherwise unobtainable. If you need help finding documentation, reach out to one of our team members who can assist you. -->


# Testing Instructions 
Select CLB1 or CLB2 in THRUST LIM page and check that N1 increase to the same as CLB(0) by the time it reaches 30000ft when climbing with FLCH-mode from 10000ft.
<!-- Describe the exact steps the team and QA testers must take in order to test the change if it is a feature addition or fix. -->

# Test Results
10000ft TO CLB (92.7)/TO 1 CLB 1 (86.7)
![image](https://user-images.githubusercontent.com/119593840/218524992-bc8a768b-b440-439d-9793-29903d345df2.png)
![image](https://user-images.githubusercontent.com/119593840/218525095-3f4fe1f7-48b0-433b-96e4-db6ffb924887.png)

30000ft TO CLB (93.1)/TO 1 CLB 1 (93.1)
![image](https://user-images.githubusercontent.com/119593840/218524028-cdfc8628-60a2-4ca8-be33-6d9059519b84.png)
![image](https://user-images.githubusercontent.com/119593840/218524227-c7e90fa0-01a2-48c8-b868-f2c4d05ef23c.png)

<!--Attach a screenshot/video of your command from your test. This will help us speed up the process of reviewing the PR. -->


# Discord Username
kuro_x#4595
<!--Add your discord username, including the number to the bottom of the PR message. This will help us get in contact if we need to.--> 
